### PR TITLE
hw6 - kubernetes volumes

### DIFF
--- a/kubernetes-volumes/cm.yaml
+++ b/kubernetes-volumes/cm.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: webserver
+  namespace: homework
+data:
+  content.txt: |
+    type: "busybox"
+    platform: "kubernetes"
+    revision: "hw6"

--- a/kubernetes-volumes/deployment.yaml
+++ b/kubernetes-volumes/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webserver
+  namespace: homework
+  labels:
+    app.kubernetes.io/instance: webserver
+    app.kubernetes.io/name: webserver
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: webserver
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: webserver
+    spec:
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #       - matchExpressions:
+      #         - key: homework
+      #           operator: In
+      #           values:
+      #           - 'true'
+      volumes:
+      - name: web-content
+        persistentVolumeClaim:
+          claimName: webserver-pvc
+      - name: custom-volume
+        configMap:
+          name: webserver
+      initContainers:
+      - name: init-container
+        image: alpine/curl
+        command: ['sh', '-c', 'echo "kubernetes-intro" > index.html && cp index.html init/ ; curl -sSk -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/metrics > /init/metrics.html']
+        volumeMounts:
+        - name: web-content
+          mountPath: /init
+      serviceAccountName: monitoring
+      containers:
+      - name: web
+        image: busybox
+        command: ['sh', '-c', 'ls -la /homework && /bin/httpd  -f -p 8000 -h /homework/']
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "rm -f /homework/index.html"]
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        ports:
+        - containerPort: 8000
+        volumeMounts:
+        - name: web-content
+          mountPath: /homework
+        - name: custom-volume
+          mountPath: /homework/conf

--- a/kubernetes-volumes/gen-kubeconfig.sh
+++ b/kubernetes-volumes/gen-kubeconfig.sh
@@ -1,0 +1,40 @@
+
+clusterName=otus-cluster
+## the Namespace and ServiceAccount name that is used for the config
+serviceAccount=$1
+namespace="$2"
+
+## New Kubeconfig file name
+newfile=otus.kubeconfig
+
+######################
+#  Main Script       #
+#                    #
+######################
+
+server=$(kubectl config view --minify --raw -o jsonpath='{.clusters[].cluster.server}' | sed 's/"//')
+secretName=$(kubectl -n $namespace get secret | grep $serviceAccount | awk '{print $1}')
+ca=$(kubectl --namespace $namespace get secret/$secretName -o jsonpath='{.data.ca\.crt}')
+token=$(kubectl --namespace $namespace get secret/$secretName -o jsonpath='{.data.token}' | base64 --decode)
+
+echo "
+---
+apiVersion: v1
+kind: Config
+clusters:
+  - name: ${clusterName}
+    cluster:
+      certificate-authority-data: ${ca}
+      server: ${server}
+contexts:
+  - name: ${serviceAccount}@${clusterName}
+    context:
+      cluster: ${clusterName}
+      namespace: ${namespace}
+      user: ${serviceAccount}
+users:
+  - name: ${serviceAccount}
+    user:
+      token: ${token}
+current-context: ${serviceAccount}@${clusterName}
+" >> ${newfile}.yaml

--- a/kubernetes-volumes/namespace.yaml
+++ b/kubernetes-volumes/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework
+  labels:
+    name: homework

--- a/kubernetes-volumes/netshoot.yaml
+++ b/kubernetes-volumes/netshoot.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-netshoot
+  namespace: homework
+  labels:
+    app: nginx-netshoot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-netshoot
+  template:
+    metadata:
+      labels:
+        app: nginx-netshoot
+    spec:
+      serviceAccountName: monitoring
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
+        ports:
+        - containerPort: 80
+      - name: netshoot
+        image: nicolaka/netshoot
+        command: ["/bin/bash"]
+        args: ["-c", "while true; do ping localhost; sleep 60;done"]
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/kubernetes-volumes/pvc.yaml
+++ b/kubernetes-volumes/pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: webserver-pvc
+  namespace: homework
+  labels:
+    app: webserver
+spec:
+  accessModes:
+  - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 100Mi
+  # storageClassName: "yc-network-hdd"
+  storageClassName: "otus-sc"

--- a/kubernetes-volumes/sa-cd.yaml
+++ b/kubernetes-volumes/sa-cd.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cd
+  namespace: homework
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: admin
+  namespace: homework
+rules:
+- apiGroups: ["*"]
+  verbs: ["*"]
+  resources: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cd-admin
+  namespace: homework
+subjects:
+- kind: ServiceAccount
+  name: cd
+  namespace: homework
+roleRef:
+  kind: Role
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: cd
+  name: cd-token
+  namespace: homework
+type: kubernetes.io/service-account-token

--- a/kubernetes-volumes/sa-monitoring.yaml
+++ b/kubernetes-volumes/sa-monitoring.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: monitoring
+  namespace: homework
+secrets:
+- name: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: monitoring
+rules:
+- verbs:
+  - get
+  nonResourceURLs:
+  - "/metrics"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: monitoring
+subjects:
+- kind: ServiceAccount
+  name: monitoring
+  namespace: homework
+roleRef:
+  kind: ClusterRole
+  name: monitoring
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: monitoring
+  namespace: homework
+  annotations:
+    kubernetes.io/service-account.name: monitoring
+type: kubernetes.io/service-account-token

--- a/kubernetes-volumes/sc.yaml
+++ b/kubernetes-volumes/sc.yaml
@@ -1,0 +1,6 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: otus-sc
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Retain

--- a/kubernetes-volumes/service.yaml
+++ b/kubernetes-volumes/service.yaml
@@ -1,0 +1,20 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: webserver
+  namespace: homework
+  labels:
+    app.kubernetes.io/instance: webserver
+    app.kubernetes.io/name: webserver
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ports:
+  - name: http-8000
+    protocol: TCP
+    port: 8000
+    targetPort: 8000
+  selector:
+    app: webserver
+  type: ClusterIP


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Создан манифест PersistentVolumeClaim, запрашивающий хранилище со storageClass по-умолчанию.
- Создан манифест configMap  с именем webserver, описывающий произвольный набор пар ключ-значение.
- В манифесте deployment.yaml изменил спецификацию volume типа emptyDir на pvc, созданный в предыдущем пункте
- В манифесте deployment.yaml добавлено монтирование ранее созданного configMap webserver как volume к основному контейнеру пода в директорию /homework/conf, так, что его содержимое можно получить, обратившись по url /conf/file
- Создан манифест storageClass с именем **otus-sc**, provisioner k8s.io/minikube-hostpath и reclaimPolicy Retain
- Манифест pvc.yaml изменен. Теперь запрашивается хранилище storageClass-а **otus-sc**

## Как запустить проект:
 - Запустить команду `kubectl apply -f kubernetes-volumes/*
`
## Как проверить работоспособность:
 - Запустить контейнер `kubectl exec -it nginx-netshoot-6d6b979467-56h45 -c netshoot -- /bin/zsh` и выполнить команду `curl webserver:8000/conf/content.tx`t
 Вывод похож на следующий: 
```
type: "busybox"
platform: "kubernetes"
revision: "hw6"
```

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
